### PR TITLE
Minimize main window during training

### DIFF
--- a/_gui_backend.ahki
+++ b/_gui_backend.ahki
@@ -38,6 +38,8 @@ StartTrainingCb(buttonCtrl, *) {
 		VerifyGtTxtFiles(buttonCtrl.Gui)
 	}
 
+	WinMinimize PROGRAM_TITLE " v." VERSION_NUMBER
+
 	StatusUpdate := ProgressStatusGui
 	StatusUpdate("Training startup", buttonCtrl.Gui)
 
@@ -66,6 +68,8 @@ StartTrainingCb(buttonCtrl, *) {
 			ErrorBox "Training ended with an error"
 		}
 	}
+
+	WinRestore PROGRAM_TITLE " v." VERSION_NUMBER
 
 	return
 }


### PR DESCRIPTION
Minimize main window during training and restore when finished.

If it is restored by hand during training it will not be possible to re-minimize it until the end 
(put a button in the "Training progress" window to be able to minimize it on request?)
