### PR TITLE
Fixed PSM in Ground-Truth Preview window

### DIFF
--- a/_helper.ahki
+++ b/_helper.ahki
@@ -237,7 +237,7 @@ OcrImageFile(imageFullPath, lang:="", tessdataDir:="") {
 	outputFile := DATA_DIR "\preview.out"
 	ocrOutput := ExecuteCommand("`"" BINARIES["tesseract"] "`" `"" imageFullPath "`" -"
 		. (lang ? " -l " lang : "")
-		. " --psm 13 -c page_separator= --tessdata-dir `"" tessdataDir "`" >`"" outputFile "`"", 2)
+		. " --psm " PSM " -c page_separator= --tessdata-dir `"" tessdataDir "`" >`"" outputFile "`"", 2)
 	return Trim(FileRead(outputFile), "`t`n`r ")
 }
 


### PR DESCRIPTION
In the Ground-Truth Preview window the PSM value was fixed at 13.
This change sets the value equal to the one present in the PSM edit box.