### PR TITLE
Preserve interword spaces

### DIFF
--- a/_helper.ahki
+++ b/_helper.ahki
@@ -230,14 +230,14 @@ CmdLogAppend(text) {
 	FileAppend text, "command.log"
 }
 
-OcrImageFile(imageFullPath, lang:="", tessdataDir:="") {
+OcrImageFile(imageFullPath, lang:="", tessdataDir:="", pis:=0) {
 	if (!tessdataDir) {
 		tessdataDir := TESSDATA
 	}
 	outputFile := DATA_DIR "\preview.out"
 	ocrOutput := ExecuteCommand("`"" BINARIES["tesseract"] "`" `"" imageFullPath "`" -"
 		. (lang ? " -l " lang : "")
-		. " --psm 13 -c page_separator= --tessdata-dir `"" tessdataDir "`" >`"" outputFile "`"", 2)
+		. " --psm " PSM " -c preserve_interword_spaces=" pis " -c page_separator= --tessdata-dir `"" tessdataDir "`" >`"" outputFile "`"", 2)
 	return Trim(FileRead(outputFile), "`t`n`r ")
 }
 

--- a/_recognition_preview.ahki
+++ b/_recognition_preview.ahki
@@ -84,8 +84,8 @@ PreviewRecognition(btnCtrl, *) {
 	closeButton := previewGui.Add("Button", "ys", "&Close")
 	closeButton.OnEvent("Click", CloseCb)
 
-	ignoreSpacesCtrl := previewGui.Add("Checkbox", "ys hp 0x20 Checked" ignoreSpaces, "Ignore space characters difference")
-	ignoreSpacesCtrl.OnEvent("Click", (ctrlObj,*)=>ignoreSpaces:=ctrlObj.Value)
+	ignoreSpacesCtrl := previewGui.Add("Checkbox", "ys hp 0x20 Checked" ignoreSpaces, "Preserve interword spaces")
+	ignoreSpacesCtrl.OnEvent("Click", PreserveInterwordSpaces)
 
 	picCtrl := previewGui.Add("Picture", "xm w" (col1Width + col2Width) " h-1", imageFullPath)
 
@@ -134,7 +134,7 @@ PreviewRecognition(btnCtrl, *) {
 
 		ocrResultCtrl.SetFont("norm cBlack")
 		ocrResultCtrl.Text := "...recognizing..."
-		recognizedValue := OcrImageFile(imageFullPath, modelNameForOcr, tessdataDirForOcr)
+		recognizedValue := OcrImageFile(imageFullPath, modelNameForOcr, tessdataDirForOcr, ignoreSpaces)
 		ocrResultCtrl.SetFont("bold " (CompareResults(recognizedValue, expectedValue) ? "cGreen" : "cRed"))
 		ocrResultCtrl.Text := recognizedValue
 
@@ -179,6 +179,11 @@ PreviewRecognition(btnCtrl, *) {
 	
 	StopSearchCallback(stopCtrl, *) {
 		searchEnabled := false
+	}
+
+	PreserveInterwordSpaces(ctrlObj, *) {
+		ignoreSpaces := ctrlObj.Value
+		RefreshGui()
 	}
 
 	CompareResults(ocrResult, gtTxtValue) {


### PR DESCRIPTION
Changed "Ignore space characters difference" checkbox to "Preserve interword spaces".
Added preserve_interword_spaces configuration parameter to eliminate extra spaces for languages chi_sim, kor, jpn and tha at the OCR level.
I left the previous deletion code which could be used for the .gt.txt file.
