### PR TITLE
Fix file name in Generate best and-or fast traineddata

### DIFF
--- a/_tesstrain.ahki
+++ b/_tesstrain.ahki
@@ -152,7 +152,7 @@ MultipleCheckpointToTraineddata(checkpointFileList, isFast) {
 	targetDir := OUTPUT_DIR "\traineddata_" bestOrFast
 	DirCreate(targetDir)
 	for (checkpointFile in checkpointFileList) {
-		outputTraineddataFile := targetDir "\" StrCutEnd(FileGetName(checkpointFile), StrLen("checkpoint")) "traineddata"
+		outputTraineddataFile := targetDir "\" StrCutEnd(FileGetName(checkpointFile), StrLen("_checkpoint")) ".traineddata"
 		Checkpoint2Traineddata(checkpointFile, outputTrainedDataFile, isFast)
 	}
 }


### PR DESCRIPTION
In the generation of the best and fast traineddata files, the file name was written with the character "_" instead of "."